### PR TITLE
Update fluentd-plugin-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
@@ -181,6 +181,42 @@ By default, the plugin sends logs to New Relic every five seconds. If you want t
 
 For more information, see the [Fluentd documentation about buffer configurations](https://docs.fluentd.org/configuration/buffer-section).
 
+## Configure UTF-16LE to UTF-8 transformation
+
+In this example for Microsoft SQL Server error logs, learn how to use Fluentd to send [UTF-16LE](https://docs.fluentd.org/input/tail#encoding-from_encoding) encoded logs to New Relic using the [required UTF-8 encoding](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general) for ingest. This example can be adapted to other encodings.
+
+We also add an appropriate `logtype` for these logs.
+
+```
+#Tail one or more log files
+<source>
+  @type tail
+  <parse>
+    @type none
+  </parse>
+  path "D:/sqlserver/error.log"
+  tag example.service
+  encoding UTF-8
+  from_encoding UTF-16LE
+</source>
+
+#Add hostname and service_name to all events with "example.service" tag
+<filter example.service>
+  @type record_transformer
+  <record>
+    service_name ${tag}
+    hostname "#{Socket.gethostname}"
+    logtype MSSQL
+  </record>
+</filter>
+
+#Forward all events to New Relic
+<match **>
+  @type newrelic
+  license_key YOUR_LICENSE_KEY
+</match>
+```
+
 ## What's next? [#what-next]
 
 Explore logging data across your platform with our [logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).


### PR DESCRIPTION
Add section for UTF-16LE to UTF-8 transformation

In some Windows environments, the Microsoft SQL Server error logs are written to disk in UTF-16LE encoding. Sending them directly to New Relic can result in formatting and display issues for the data stored to NRDB, since New Relic's API requires UTF-8 encoding ([reference](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general)).

Configuration is required in order to send any UTF-16 logs as UTF-8. Fluentd supports the required transformation between encodings ([reference](https://docs.fluentd.org/input/tail#encoding-from_encoding)).